### PR TITLE
Fix outdated numba import

### DIFF
--- a/src/ssht_numba/wrappers.py
+++ b/src/ssht_numba/wrappers.py
@@ -5,7 +5,7 @@ The function signatures are defined in the SSHT docs.
 import cffi
 import numba as nb
 import numpy as np
-from numba import cffi_support
+import numba.core.typing.cffi_utils as cffi_support
 
 from . import _ssht_cffi
 


### PR DESCRIPTION
The cffi_support, which was heretofore deprecated, has now been entirely removed in favor of this longer reference.